### PR TITLE
Implement module content pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,7 +5,9 @@ import styled from 'styled-components';
 const App = () => {
   return (
     <Wrap>
-      <SideBar />
+      <SideBarWrap>
+        <SideBar />
+      </SideBarWrap>
       <ModuleSelectionPage />
     </Wrap>
   );
@@ -14,6 +16,10 @@ const App = () => {
 const Wrap = styled.div`
   display: flex;
   flex-direction: row;
+`;
+
+const SideBarWrap = styled.div`
+  padding-right: 75px;
 `;
 
 export { App };

--- a/src/components/SideBar.js
+++ b/src/components/SideBar.js
@@ -5,7 +5,7 @@ import { useState } from 'react';
 
 const SideBar = () => {
     const [collapsed, setCollapsed] = useState(true);
-    return (<div>
+    return (
         <SideBarWrap
             collapsed={collapsed}
         >
@@ -31,11 +31,12 @@ const SideBar = () => {
                 <FooterWrap>NeoCirc LLC</FooterWrap>
             </SidebarFooter>}
         </SideBarWrap>
-    </div>);
+    );
 }
 
 const SideBarWrap = styled(ProSidebar)`
     height: 100vh;
+    position: fixed;
 `;
 
 const FooterWrap = styled.div`

--- a/src/components/modules/ModuleSelectionPage.js
+++ b/src/components/modules/ModuleSelectionPage.js
@@ -20,8 +20,9 @@ const ModuleSelectionPage = () => {
     // Headers for corresponding pages based on selection state
     const headers = [
         'Module Selection Page',
-        'Content #1',
-        'Content #2',
+        '',
+        '',
+        'Quiz'
     ];
 
     return (
@@ -96,10 +97,21 @@ const ModuleSelectionPage = () => {
                 as={Col}
                 variant="outline-primary"
                 onClick={() => setSelection(0)}
-                style={{ marginTop: '20px' }}
+                style={{ marginTop: '20px', height: "40px", width: "50%"}}
             >
                 Back
-            </Button> }
+            </Button>
+            }
+
+            {(selection === 1 || selection === 2) && <Button
+                as={Col}
+                variant="outline-primary"
+                onClick={() => setSelection(3)}
+                style={{ marginTop: '20px', height: "40px", width: "50%" }}
+            >
+                Take Quiz
+            </Button>
+            }
         </Wrap>
     );
 };

--- a/src/components/modules/content/ModuleContent1.js
+++ b/src/components/modules/content/ModuleContent1.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import Card from 'react-bootstrap/Card';
-import Button from 'react-bootstrap/Button';
+import Figure from 'react-bootstrap/Figure';
 
 const ModuleContent1 = () => {
     /*
@@ -10,14 +10,67 @@ const ModuleContent1 = () => {
     */
     return (
         <Wrap>
-            <Card style={{ width: '18rem' }}>
+
+            <Card style={{ width: '100%' }}>
+                <Card.Header>
+                    <HeadingWrap>
+                        {"Introduction"}
+                    </HeadingWrap>
+                </Card.Header>
                 <Card.Body>
-                <Card.Title>Card Title</Card.Title>
-                <Card.Text>
-                    Some quick example text to build on the card title and make up the bulk of
-                    the card's content.
-                </Card.Text>
-                <Button variant="primary">Go somewhere</Button>
+                    <Card.Text>
+                        <ParagraphWrap width="100%">
+                            {"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lacus sed viverra tellus in hac habitasse platea. Non tellus orci ac auctor augue mauris augue neque. Turpis massa tincidunt dui ut. Mattis pellentesque id nibh tortor id aliquet lectus proin. Sit amet dictum sit amet justo donec. Faucibus pulvinar elementum integer enim neque volutpat ac tincidunt vitae. Eget nunc scelerisque viverra mauris in aliquam sem. In metus vulputate eu scelerisque felis. Aliquam purus sit amet luctus venenatis lectus magna fringilla. Nulla posuere sollicitudin aliquam ultrices sagittis orci a scelerisque. Eros in cursus turpis massa. Justo laoreet sit amet cursus sit. Lacus luctus accumsan tortor posuere. In vitae turpis massa sed. Scelerisque eu ultrices vitae auctor eu augue."}
+                        </ParagraphWrap>
+                        <br></br>
+                        <br></br>
+                        <br></br>
+                        <HorizontalWrap>
+                            <ParagraphWrap width="50%">
+                                {"Proin gravida et mauris at mattis. Pellentesque semper dapibus dui non volutpat. " +
+                                    "Aenean consequat mollis nulla id ornare. Donec aliquet elit hendrerit porttitor semper. " +
+                                    "Pellentesque a facilisis massa. Sed et elit in augue semper iaculis a ac nisi. Aliquam " +
+                                    "ac volutpat nisl. Proin eget suscipit purus. Urna et pharetra pharetra massa. " +
+                                    "Odio aenean sed adipiscing diam. Et netus et malesuada fames ac turpis egestas. " +
+                                    "Arcu non sodales neque sodales ut etiam sit. At auctor urna nunc id cursus metus " +
+                                    "aliquam. Viverra suspendisse potenti nullam ac. Urna nunc id cursus metus aliquam " +
+                                    "eleifend. Nulla porttitor massa id neque aliquam. Mauris in aliquam sem fringilla ut " +
+                                    "morbi tincidunt augue. Lobortis mattis aliquam faucibus purus in massa tempor nec. At " +
+                                    "in tellus integer feugiat scelerisque varius morbi enim. Dolor sit amet consectetur adipiscing. " +
+                                    "Aliquet porttitor lacus luctus accumsan tortor posuere ac ut consequat. Dictum non consectetur a erat."}
+                            </ParagraphWrap>
+                            <ImageWrap width="45%">
+                                <Figure>
+                                    <Figure.Image
+                                        src="https://assets.justinmind.com/wp-content/webp-express/webp-images/uploads/2018/11/Lorem-Ipsum-alternatives.png.webp"
+                                    />
+                                    <Figure.Caption>
+                                        <FigureCaptionWrap>
+                                            Nulla vitae elit libero, a pharetra augue mollis interdum. Aenean consequat mollis nulla id ornare. Donec aliquet elit hendrerit porttitor semper.
+                                            Odio aenean sed adipiscing diam. Et netus et malesuada fames ac turpis egestas.
+                                        </FigureCaptionWrap>
+                                    </Figure.Caption>
+                                </Figure>
+                            </ImageWrap>
+                        </HorizontalWrap>
+                        <br></br>
+                        <br></br>
+                        <br></br>
+                        <ParagraphWrap width="100%">
+                            {"Augue ut lectus arcu bibendum at varius vel pharetra. " +
+                                "Odio aenean sed adipiscing diam. Et netus et malesuada fames ac turpis egestas. " +
+                                "Pellentesque a facilisis massa. Sed et elit in augue semper iaculis a ac nisi. Aliquam " +
+                                "ac volutpat nisl. Proin eget suscipit purus. Urna et pharetra pharetra massa. " +
+                                "Nisl nunc mi ipsum faucibus vitae aliquet nec ullamcorper sit. " +
+                                "Arcu non sodales neque sodales ut etiam sit. At auctor urna nunc id cursus metus " +
+                                "aliquam. Viverra suspendisse potenti nullam ac. Urna nunc id cursus metus aliquam " +
+                                "eleifend. Nulla porttitor massa id neque aliquam. Mauris in aliquam sem fringilla ut " +
+                                "morbi tincidunt augue. Lobortis mattis aliquam faucibus purus in massa tempor nec. At " +
+                                "in tellus integer feugiat scelerisque varius morbi enim. Dolor sit amet consectetur adipiscing. " +
+                                "Aliquet porttitor lacus luctus accumsan tortor posuere ac ut consequat. Dictum non consectetur a erat."}
+                        </ParagraphWrap>
+                        
+                    </Card.Text>
                 </Card.Body>
             </Card>
         </Wrap>
@@ -30,6 +83,34 @@ const ModuleContent1 = () => {
 */
 const Wrap = styled.div`
     padding: 0px;
+`;
+
+const HeadingWrap = styled.h2`
+    margin-left: auto;
+    margin-right: auto;
+`;
+
+const ParagraphWrap = styled.span`
+    width: ${props => props.width};
+    vertical-align: top;
+    padding: 0px;
+    font-size: 25px;
+    display: inline-block;
+`;
+
+const ImageWrap = styled.div`
+    width: ${props => props.width};
+    margin-left: 2.5%;
+    margin-right: 2.5%;
+    display:inline-block
+`;
+
+const HorizontalWrap = styled.div`
+    
+`;
+
+const FigureCaptionWrap = styled.span`
+    font-size: 20px;
 `;
 
 export { ModuleContent1 };

--- a/src/components/modules/content/ModuleContent2.js
+++ b/src/components/modules/content/ModuleContent2.js
@@ -1,42 +1,83 @@
-import Table from 'react-bootstrap/Table';
+import styled from 'styled-components';
+import Card from 'react-bootstrap/Card';
+import Figure from 'react-bootstrap/Figure';
 
 const ModuleContent2 = () => {
     /*
         @Kevin, take a look at my comments on ModuleContent1.js, same thing here
     */
     return (
-        <div>
-            <Table striped bordered hover>
-                <thead>
-                    <tr>
-                    <th>#</th>
-                    <th>First Name</th>
-                    <th>Last Name</th>
-                    <th>Username</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                    <td>1</td>
-                    <td>Mark</td>
-                    <td>Otto</td>
-                    <td>@mdo</td>
-                    </tr>
-                    <tr>
-                    <td>2</td>
-                    <td>Jacob</td>
-                    <td>Thornton</td>
-                    <td>@fat</td>
-                    </tr>
-                    <tr>
-                    <td>3</td>
-                    <td colSpan="2">Larry the Bird</td>
-                    <td>@twitter</td>
-                    </tr>
-                </tbody>
-            </Table>
-        </div>
+        <Wrap>
+
+            <Card style={{ width: '100%' }}>
+                <Card.Header>
+                    <HeadingWrap>
+                        {"Complications"}
+                    </HeadingWrap>
+                </Card.Header>
+                <Card.Body>
+                    <Card.Text>
+                        <ParagraphWrap width="100%">
+                            {"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lacus sed viverra tellus in hac habitasse platea. Non tellus orci ac auctor augue mauris augue neque. Turpis massa tincidunt dui ut. Mattis pellentesque id nibh tortor id aliquet lectus proin. Sit amet dictum sit amet justo donec. Faucibus pulvinar elementum integer enim neque volutpat ac tincidunt vitae. Eget nunc scelerisque viverra mauris in aliquam sem. In metus vulputate eu scelerisque felis. Aliquam purus sit amet luctus venenatis lectus magna fringilla. Nulla posuere sollicitudin aliquam ultrices sagittis orci a scelerisque. Eros in cursus turpis massa. Justo laoreet sit amet cursus sit. Lacus luctus accumsan tortor posuere. In vitae turpis massa sed. Scelerisque eu ultrices vitae auctor eu augue."}
+                        </ParagraphWrap>
+                        <br></br>
+                        <br></br>
+                        <br></br>
+                        <ImageWrap width="100%">
+                            <Figure
+                                style={{display: 'flex', justifyContent: 'center'}}>
+                                <Figure.Image
+                                    src="https://lucidnarratives.com/wp-content/uploads/2019/01/Bad-Brand-Storytelling-Videos.png"
+                                />
+                            </Figure>
+                        </ImageWrap>
+                        <br></br>
+                        <br></br>
+                        <br></br>
+                        <ParagraphWrap width="100%">
+                            {"Augue ut lectus arcu bibendum at varius vel pharetra. " +
+                                "Odio aenean sed adipiscing diam. Et netus et malesuada fames ac turpis egestas. " +
+                                "Pellentesque a facilisis massa. Sed et elit in augue semper iaculis a ac nisi. Aliquam " +
+                                "ac volutpat nisl. Proin eget suscipit purus. Urna et pharetra pharetra massa. " +
+                                "Nisl nunc mi ipsum faucibus vitae aliquet nec ullamcorper sit. " +
+                                "Arcu non sodales neque sodales ut etiam sit. At auctor urna nunc id cursus metus " +
+                                "aliquam. Viverra suspendisse potenti nullam ac. Urna nunc id cursus metus aliquam " +
+                                "eleifend. Nulla porttitor massa id neque aliquam. Mauris in aliquam sem fringilla ut " +
+                                "morbi tincidunt augue. Lobortis mattis aliquam faucibus purus in massa tempor nec. At " +
+                                "in tellus integer feugiat scelerisque varius morbi enim. Dolor sit amet consectetur adipiscing. " +
+                                "Aliquet porttitor lacus luctus accumsan tortor posuere ac ut consequat. Dictum non consectetur a erat."}
+                        </ParagraphWrap>
+                        
+                    </Card.Text>
+                </Card.Body>
+            </Card>
+
+        </Wrap>
+
+        
     )
 };
+
+const Wrap = styled.div`
+    padding: 0px;
+`;
+
+const HeadingWrap = styled.h2`
+    margin-left: auto;
+    margin-right: auto;
+`;
+
+const ParagraphWrap = styled.span`
+    width: ${props => props.width};
+    vertical-align: top;
+    padding: 0px;
+    font-size: 25px;
+    display: inline-block;
+`;
+
+const ImageWrap = styled.div`
+    width: ${props => props.width};
+    
+`;
 
 export { ModuleContent2 };


### PR DESCRIPTION
Implement module content pages: first page demonstrates a typical content page that contains an image and text, and second page demonstrates a typical content page for a video.
![Capture11](https://user-images.githubusercontent.com/57064021/143670279-f5109ed7-02d8-47cc-a172-1c3ce66a639f.PNG)
![Capture12](https://user-images.githubusercontent.com/57064021/143670278-506306a5-0465-4c13-a6f3-bcee617b51e2.PNG)
Back and Take Quiz buttons are located at the bottom of each module content page, so that users are able to navigate back to the module selection page, or to the module's quiz.
![Capture13](https://user-images.githubusercontent.com/57064021/143670383-fa35a8e6-0796-4603-9e1e-5039528193ef.PNG)


