### PR TITLE
Close sidebar when clicking outside & push content to the side

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -94,6 +94,7 @@ const ContentWrap = styled.div`
 `;
 
 const SideBarWrap = styled.div`
+  padding-right: 80px;
   @media (max-width: 768px) {
     padding-right: 0px;
   }

--- a/src/App.js
+++ b/src/App.js
@@ -94,7 +94,6 @@ const ContentWrap = styled.div`
 `;
 
 const SideBarWrap = styled.div`
-  padding-right: 80px;
   @media (max-width: 768px) {
     padding-right: 0px;
   }

--- a/src/components/SideBar.js
+++ b/src/components/SideBar.js
@@ -9,6 +9,12 @@ const SideBar = () => {
     const [collapsed, setCollapsed] = useState(true);
     const [toggled, setToggled] = useState(false);
     const navigate = useNavigate();
+    const clickSidebarContent = (path) => {
+        if (!collapsed) {
+            setCollapsed(true);
+        }
+        navigate(path);
+    }
     return (<>
         {!toggled && <ToggleBurger>
             <ToggleButton onClick={() => {
@@ -42,19 +48,31 @@ const SideBar = () => {
             </SideBarHeaderWrap>
             <SidebarContent>
                 <Menu iconShape="square">
-                    <MenuItem icon={<FaHome />} onClick={() => navigate('/')}>Home</MenuItem>
-                    <MenuItem icon={<FaInfo />} onClick={() => navigate('/about')}>About Us</MenuItem>
+                    <MenuItem icon={<FaHome />} onClick={() => clickSidebarContent('/')}>Home</MenuItem>
+                    <MenuItem icon={<FaInfo />} onClick={() => clickSidebarContent('/about')}>About Us</MenuItem>
                     <SubMenu title="FAQ" icon={<FaQuestion />} >
                         <MenuItem onClick={() => navigate('/GenFAQPage')}>General</MenuItem>
                     </SubMenu>
-                    <MenuItem icon={<FaFolder />} onClick={() => navigate('/sources')}>Source</MenuItem>
-                    <MenuItem icon={<FaMailBulk />} onClick={() => navigate('/contact')}>Contact Us!</MenuItem>
+                    <MenuItem icon={<FaFolder />} onClick={() => clickSidebarContent('/source')}>Source</MenuItem>
+                    <MenuItem icon={<FaMailBulk />} onClick={() => clickSidebarContent('/contact')}>Contact Us!</MenuItem>
                 </Menu>
             </SidebarContent>
             {collapsed ? null : <SidebarFooter>
                 <FooterWrap>NeoCirc LLC</FooterWrap>
             </SidebarFooter>}
         </SideBarWrap>
+        {!collapsed && <OverlayDiv onClick={() => {
+            if (toggled) {
+                if (collapsed === false) {
+                    setCollapsed(true);
+                }
+                setToggled(!toggled);
+            } else {
+                setCollapsed(!collapsed);
+            }
+        }}>
+            Testing    
+        </OverlayDiv>}
     </>);
 }
 
@@ -108,6 +126,16 @@ const ToggleBurger = styled.div`
 
 const ToggleButton = styled(Button)`
     padding: 15px;
+`;
+
+const OverlayDiv = styled.div`
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background-color: rgba(0, 0, 0, 0.3);
+    z-index: 100;
 `;
 
 export { SideBar };

--- a/src/components/SideBar.js
+++ b/src/components/SideBar.js
@@ -70,15 +70,16 @@ const SideBar = () => {
             } else {
                 setCollapsed(!collapsed);
             }
-        }}>
-            Testing    
-        </OverlayDiv>}
+        }} />}
     </>);
 }
 
 const SideBarWrap = styled(ProSidebar)`
-    min-height: 100vh;
-    height: 100%;
+    height: 100vh;
+    position: fixed;
+    @media (max-width: 768px) {
+        width: 100%;
+    }
 `;
 
 const FooterWrap = styled.div`

--- a/src/components/SideBar.js
+++ b/src/components/SideBar.js
@@ -59,8 +59,8 @@ const SideBar = () => {
 }
 
 const SideBarWrap = styled(ProSidebar)`
-    height: 100vh;
-    position: fixed;
+    min-height: 100vh;
+    height: 100%;
 `;
 
 const FooterWrap = styled.div`

--- a/src/components/SideBar.js
+++ b/src/components/SideBar.js
@@ -10,8 +10,13 @@ const SideBar = () => {
     const [toggled, setToggled] = useState(false);
     const navigate = useNavigate();
     const clickSidebarContent = (path) => {
-        if (!collapsed) {
-            setCollapsed(true);
+        if (toggled) {
+            if (collapsed === false) {
+                setCollapsed(true);
+            }
+            setToggled(!toggled);
+        } else {
+            setCollapsed(!collapsed);
         }
         navigate(path);
     }
@@ -53,7 +58,7 @@ const SideBar = () => {
                     <SubMenu title="FAQ" icon={<FaQuestion />} >
                         <MenuItem onClick={() => navigate('/GenFAQPage')}>General</MenuItem>
                     </SubMenu>
-                    <MenuItem icon={<FaFolder />} onClick={() => clickSidebarContent('/source')}>Source</MenuItem>
+                    <MenuItem icon={<FaFolder />} onClick={() => clickSidebarContent('/sources')}>Source</MenuItem>
                     <MenuItem icon={<FaMailBulk />} onClick={() => clickSidebarContent('/contact')}>Contact Us!</MenuItem>
                 </Menu>
             </SidebarContent>


### PR DESCRIPTION
This PR fixes some minor bugs relating to the sidebar:

1. As requested by the client, the main content will be pushed to the side when the sidebar opens up.
2. Ticket that Kevin opened, the side bar will now close if you click anything outside the sidebar for fluidity.

![image](https://user-images.githubusercontent.com/16738576/161413174-ff02c560-cbc0-46b8-9f4e-9bbdc09bcf65.png)
